### PR TITLE
add GitHub Action Workflow for push events

### DIFF
--- a/.eslintcache
+++ b/.eslintcache
@@ -1,1 +1,0 @@
-{"/Users/robertg/innoq/hotshot/app.js":{"size":2765,"mtime":1549554314745,"results":{"filePath":"/Users/robertg/innoq/hotshot/app.js","messages":[],"errorCount":0,"warningCount":0,"fixableErrorCount":0,"fixableWarningCount":0},"hashOfConfig":"p6upi1"}}

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '17.x'
+      - name: yarn install
+        run: yarn install
       - name: yarn test
         run: yarn test 
 

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -1,0 +1,33 @@
+name: on Push
+
+on: push
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17.x'
+      - name: yarn test
+        run: yarn test 
+
+  deploy:
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Deploy to Heroku
+        uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "hotshot-production"
+          heroku_email: ${{secrets.HEROKU_EMAIL}}

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ const puppeteer = require('puppeteer')
 const express = require('express')
 const URL = require('url').URL
 const app = express()
-const negotiate = require('express-negotiate')
+require('express-negotiate')
 
 app.set('etag', 'strong')
 
@@ -46,11 +46,11 @@ app.get('/shoot', async (req, res) => {
       'image/webp;q=0.9': () => {
         format = 'webp'
       },
-      'default': () => {
+      default: () => {
         format = 'jpeg'
       }
     })
-    console.log(`accept: ${req.headers['accept']}, sending ${format}...`)
+    console.log(`accept: ${req.headers.accept}, sending ${format}...`)
 
     const screenshot = await takeScreenshot(target, selector, padding, format)
     if (screenshot) {


### PR DESCRIPTION
## Was macht es?

Migriert die Pipeline von [Travis CI](https://github.com/innoq/hotshot/commit/eaca674da1dad08ac53104e6933f8a86a2840864) zu GitHub Actions

## Wie geht es?

- Für jeden Push, egal für welchen Branch, wird `yarn test` ausgeführt
- Für jeden Push in den Main Branch wird zusätzlich nach dem Test Job ein Deploy Job ausgeführt, für Heroku.

## Was muss ich noch tun?

- Secrets anlegen: [Anleitung](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
  - HEROKU_API_KEY
  - HEROKU_EMAIL

## Warum ist die Pipeline rot? :red_circle: 
- Die Tests laufen und schlagen fehl. :slightly_smiling_face: 